### PR TITLE
Agregando comentario para correr script en OSX

### DIFF
--- a/generate_file.bash
+++ b/generate_file.bash
@@ -1,2 +1,3 @@
 #!/bin/bash
+# en caso de estar usando OSX: bs=2m
 dd if=/dev/zero of=blob.bin  bs=2M  count=1


### PR DESCRIPTION
En OSX la opción de block size va en minúscula, linux no lo soporta de esta forma, así que no podemos usar lo mismo para ambos (desconozco como es en windows).