### PR TITLE
Change curl bash script to match puma's default port

### DIFF
--- a/curl_forexpr.bash
+++ b/curl_forexpr.bash
@@ -8,7 +8,7 @@ echo "Starting requests"
 
 for (( c=0; c<=$END; c++ ))
 do
-    content= curl -sS -I http://localhost:5000/io_bound
+    content= curl -sS -I http://localhost:9292/io_bound
     echo "${content}" >> out.html
 	sleep $[ ( $RANDOM % $RAND_REQ )  + 1 ]s
 done


### PR DESCRIPTION
This way the students won't have to change the script or to call puma with parameters specifying the port.